### PR TITLE
Improve env detection in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,7 @@ end
 <!-- ... -->
 <body class="antialiased bg-white">
   <%= @inner_content %>
-  <!--
-  If you're deploying with Releases, Mix.env will be unavailable in production. In this case, set and detect the environment using application config. E.g. `Application.compile_env(:my_app, :env) == :dev`
-  -->
-  <.tw_screen_size :if={Mix.env() == :dev} />
+  <.tw_screen_size :if={Application.get_env(:my_app, :dev_routes)} />
 </body>
 ```
 


### PR DESCRIPTION
Hi!

I am making PR for you to consider.
Instead of writing a comment about how `Mix.env()` does not work with releases, you could use something that is already in every new phoenix project template. `config :my_app, :dev_routes`. It is enabled in `:dev`.

You might not like tying tw_screen_size to dev_routes because, well, the name says "routes" and that is kind of abuse. However, the feature is used with other dev stuff, so maybe it is OK?

If you find dev_routes not acceptable, it is probably better to suggest something along the same lines:

`config :my_app, tw_screen_size: true` in `dev.exs` and remove any usage of `Mix.env()` from code.

I hope it helps :)